### PR TITLE
Pin GitPython dependency (#143)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='openaps',
     include_package_data = True,
     install_requires = [
       'pyserial', 'python-dateutil', 'argcomplete',
-      'gitpython', 'mock', 'nose',
+      'gitpython <= 2.1.11', 'mock', 'nose',
       'decocare > 0.0.26', 'dexcom_reader >= 0.1.8'
     ],
     dependency_links = [


### PR DESCRIPTION
As of v2.1.12, GitPython deprecates python 2.7, which breaks this script.